### PR TITLE
feat: added coerce function

### DIFF
--- a/include/version_weaver.h
+++ b/include/version_weaver.h
@@ -13,7 +13,7 @@ static constexpr size_t MAX_VERSION_LENGTH = 256;
 bool validate(std::string_view version);
 
 bool satisfies(std::string_view version, std::string_view range);
-std::string coerce(const std::string& version);
+std::optional<std::string> coerce(const std::string& version);
 std::string minimum(std::string_view range);
 
 // A normal version number MUST take the form X.Y.Z where X, Y, and Z are

--- a/src/version_weaver.cpp
+++ b/src/version_weaver.cpp
@@ -6,7 +6,7 @@
 namespace version_weaver {
 bool validate(std::string_view version) { return parse(version).has_value(); }
 
-std::string coerce(const std::string& version) {
+std::optional<std::string> coerce(const std::string& version) {
   if (version.empty()) {
     return std::nullopt;
   }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -110,7 +110,7 @@ TEST(basictests, order) {
   }
 }
 
-using CoerceData = std::pair<std::string, std::string>;
+using CoerceData = std::pair<std::string, std::optional<std::string>>;
 std::vector<CoerceData> coerce_values = {
     {"001", "1.0.0"},
     {"01.002.03", "1.2.3"},
@@ -130,7 +130,7 @@ std::vector<CoerceData> coerce_values = {
     {"1", "1.0.0"},
     {"1.2.x", "1.2.0"},
     {"alpha1.2.3", "1.2.3"},
-    {"", "0.0.0"},
+    {"", std::nullopt},
     {".1", "1.0.0"},
     {".1.", "1.0.0"},
     {"..1", "1.0.0"},
@@ -177,6 +177,10 @@ std::vector<CoerceData> coerce_values = {
 TEST(basictests, coerce) {
   for (const auto& [input, expected] : coerce_values) {
     auto result = version_weaver::coerce(input);
-    ASSERT_EQ(result, expected);
+    if (expected.has_value()) {
+      ASSERT_EQ(result, expected.value());
+    } else {
+      ASSERT_FALSE(result.has_value());
+    }
   }
 }


### PR DESCRIPTION
complements the coerce method to parse and normalize version strings in semver format. It processes inputs such as 1, 1.2, v1.2.3 and returns normalized outputs (1.0.0, 1.2.0, 1.2.3). The default value for empty inputs is 0.0.0.0.

the method uses regex for parsing. I would be grateful if you have any suggestions for reliability and potential alternatives