### PR TITLE
chore: add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 cmake-build-debug
 tests/Testing
 Testing
+.vscode


### PR DESCRIPTION
For my local setup I needed to tweak my vscode cpp settings for the workspace, this causes the `.vscode` dir to be created and I need to be careful not to commit it so if it'd be alright with you I'd like to add the directory to the gitignore :slightly_smiling_face: 