### PR TITLE
Support all release types in `inc` operation

### DIFF
--- a/include/version_weaver.h
+++ b/include/version_weaver.h
@@ -95,12 +95,12 @@ enum release_type {
   MAJOR,
   MINOR,
   PATCH,
+  PRE_MAJOR,
+  PRE_MINOR,
+  PRE_PATCH,
   // TODO: also support
-  //  - PRE_MAJOR
-  //  - PRE_MINOR
-  //  - PRE_PATCH
-  //  - PRE_RELEASE
   //  - RELEASE
+  //  - PRE_RELEASE
 };
 
 // Increment the version according to the provided release type.

--- a/include/version_weaver.h
+++ b/include/version_weaver.h
@@ -98,8 +98,8 @@ enum release_type {
   PRE_MAJOR,
   PRE_MINOR,
   PRE_PATCH,
+  RELEASE,
   // TODO: also support
-  //  - RELEASE
   //  - PRE_RELEASE
 };
 

--- a/include/version_weaver.h
+++ b/include/version_weaver.h
@@ -81,6 +81,7 @@ enum parse_error {
   INVALID_MAJOR,
   INVALID_MINOR,
   INVALID_PATCH,
+  INVALID_PRERELEASE,
   INVALID_RELEASE_TYPE,
 };
 
@@ -99,8 +100,7 @@ enum release_type {
   PRE_MINOR,
   PRE_PATCH,
   RELEASE,
-  // TODO: also support
-  //  - PRE_RELEASE
+  PRE_RELEASE,
 };
 
 // Increment the version according to the provided release type.

--- a/src/version_weaver.cpp
+++ b/src/version_weaver.cpp
@@ -84,6 +84,12 @@ std::expected<std::string, parse_error> inc(version input,
       result = version_weaver::version{input.major, input.minor, incremented};
       break;
     }
+    case RELEASE: {
+      if (!input.pre_release.has_value()) {
+        return std::unexpected(parse_error::INVALID_INPUT);
+      }
+      return version_weaver::version{input.major, input.minor, input.patch};
+    };
     default:
       return std::unexpected(parse_error::INVALID_RELEASE_TYPE);
   }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -244,6 +244,18 @@ std::vector<IncTestData> inc_values = {
     {version_weaver::version{"1", "2", "0", "1"}, "1.2.0-1",
      version_weaver::release_type::PRE_PATCH, "1.2.1-0",
      version_weaver::version{"1", "2", "1", "0"}},
+    {version_weaver::version{"1", "0", "0", "1"}, "1.0.0-1",
+     version_weaver::release_type::RELEASE, "1.0.0",
+     version_weaver::version{"1", "0", "0"}},
+    {version_weaver::version{"1", "2", "0", "1"}, "1.2.0-1",
+     version_weaver::release_type::RELEASE, "1.2.0",
+     version_weaver::version{"1", "2", "0"}},
+    {version_weaver::version{"1", "2", "3", "1"}, "1.2.3-1",
+     version_weaver::release_type::RELEASE, "1.2.3",
+     version_weaver::version{"1", "2", "3"}},
+    {version_weaver::version{"1", "2", "3"}, "1.2.3",
+     version_weaver::release_type::RELEASE, "1.2.3",
+     std::unexpected(version_weaver::parse_error::INVALID_INPUT)},
 };
 
 TEST(basictests, inc) {

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -229,6 +229,21 @@ std::vector<IncTestData> inc_values = {
     {version_weaver::version{"1", "2", "3", "alpha.0.beta"},
      "1.2.3-alpha.0.beta", version_weaver::release_type::PATCH, "1.2.3",
      version_weaver::version{"1", "2", "3"}},
+    {version_weaver::version{"1", "2", "0"}, "1.2.0",
+     version_weaver::release_type::PRE_MAJOR, "2.0.0-0",
+     version_weaver::version{"2", "0", "0", "0"}},
+    {version_weaver::version{"1", "2", "0"}, "1.2.0",
+     version_weaver::release_type::PRE_MINOR, "1.3.0-0",
+     version_weaver::version{"1", "3", "0", "0"}},
+    {version_weaver::version{"1", "2", "3", "1"}, "1.2.3-1",
+     version_weaver::release_type::PRE_MINOR, "1.3.0-0",
+     version_weaver::version{"1", "3", "0", "0"}},
+    {version_weaver::version{"1", "2", "0"}, "1.2.0",
+     version_weaver::release_type::PRE_PATCH, "1.2.1-0",
+     version_weaver::version{"1", "2", "1", "0"}},
+    {version_weaver::version{"1", "2", "0", "1"}, "1.2.0-1",
+     version_weaver::release_type::PRE_PATCH, "1.2.1-0",
+     version_weaver::version{"1", "2", "1", "0"}},
 };
 
 TEST(basictests, inc) {

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -256,6 +256,12 @@ std::vector<IncTestData> inc_values = {
     {version_weaver::version{"1", "2", "3"}, "1.2.3",
      version_weaver::release_type::RELEASE, "1.2.3",
      std::unexpected(version_weaver::parse_error::INVALID_INPUT)},
+    {version_weaver::version{"1", "2", "4"}, "1.2.4",
+     version_weaver::release_type::PRE_RELEASE, "1.2.5-0",
+     version_weaver::version{"1", "2", "5", "0"}},
+    {version_weaver::version{"1", "2", "3", "0"}, "1.2.3-0",
+     version_weaver::release_type::PRE_RELEASE, "1.2.3-1",
+     version_weaver::version{"1", "2", "3", "1"}},
 };
 
 TEST(basictests, inc) {


### PR DESCRIPTION
This PR adds support for the remaining release types that can be passed to the `inc` function, making the `inc` function quite complete

One noticeable thing I didn't do is supporting prerelease increments on versions which prereleases are not integers as that looks quite complex to me and something that I would like to do as a followup